### PR TITLE
Update Feb 2020

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -45,6 +45,7 @@ val MonixVersion = "$monix_version$"
 val ZIOVersion = "$zio_version$"
 val ShapelessVersion = "$shapeless_version$"
 val FS2Version = "$fs2_version$"
+val AmmoniteVersion = "$ammonite_version$"
 
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.3.1",
@@ -69,8 +70,7 @@ libraryDependencies ++= Seq(
   // type classes
   "com.github.mpilquist" %% "simulacrum" % "0.12.0",
   // li haoyi ammonite repl embed
-  "com.lihaoyi" % "ammonite" % "1.6.7" % "test" cross CrossVersion.full
-
+  "com.lihaoyi" % "ammonite" % AmmoniteVersion % "test" cross CrossVersion.full
 )
 
 //ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }
@@ -80,17 +80,6 @@ resolvers ++= Seq(
   "Secured Central Repository" at "https://repo1.maven.org/maven2",
   Resolver.sonatypeRepo("snapshots")
 )
-
-// scalariform
-//scalariformSettings
-
-// ScalariformKeys.preferences := ScalariformKeys.preferences.value
-//   .setPreference(AlignSingleLineCaseStatements, true)
-//   .setPreference(DoubleIndentClassDeclaration, true)
-//   .setPreference(IndentLocalDefs, true)
-//   .setPreference(IndentPackageBlocks, true)
-//   .setPreference(IndentSpaces, 2)
-//   .setPreference(MultilineScaladocCommentsStartOnFirstLine, false)
 
 // ammonite repl
 sourceGenerators in Test += Def.task {

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -5,7 +5,7 @@ organization=org.example
 package = $organization$.$name;format="norm,word"$
 version=0.1-SNAPSHOT
 
-scala_version = 2.13.1
+scala_version = 2.12.10
 
 cats_version = 2.1.0
 cats_effect_version = 2.1.1
@@ -13,3 +13,4 @@ monix_version = 3.1.0
 shapeless_version = 2.3.3
 zio_version = 1.0.0-RC17
 fs2_version = 2.2.2
+ammonite_version = 2.0.0

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -5,11 +5,11 @@ organization=org.example
 package = $organization$.$name;format="norm,word"$
 version=0.1-SNAPSHOT
 
-scala_version = 2.12.8
+scala_version = 2.13.1
 
-cats_version = 2.0.0
-cats_effect_version = 2.0.0
-monix_version = 3.0.0
+cats_version = 2.1.0
+cats_effect_version = 2.1.1
+monix_version = 3.1.0
 shapeless_version = 2.3.3
-zio_version = 1.0.0-RC16
-fs2_version = 2.0.1
+zio_version = 1.0.0-RC17
+fs2_version = 2.2.2


### PR DESCRIPTION
Update the library versions as follows:

scala_version = 2.13.1
cats_version = 2.1.0
cats_effect_version = 2.1.1
monix_version = 3.1.0
shapeless_version = 2.3.3
zio_version = 1.0.0-RC17
fs2_version = 2.2.2